### PR TITLE
Enable basic checks on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 
 sudo: false
 
-before_install: npm install -g bower
+before_install: npm install -g bower jshint
 
 install: bower install
+
+script: jshint importer-api.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+
+sudo: false
+
+before_install: npm install -g bower
+
+install: bower install


### PR DESCRIPTION
Enable builds with Travis CI. The module doesn't have any tests of its own, so we just test for a sane Bower config, and test that the Javascript conforms to basic good style rules.
